### PR TITLE
renamed Trie::get to Trie::get_view

### DIFF
--- a/src/trie/hash.rs
+++ b/src/trie/hash.rs
@@ -405,7 +405,7 @@ mod test {
 
         hash_trie.insert(keys_a.clone(), "A".to_string());
 
-        assert_eq!(hash_trie.get(keys_a).unwrap().value(), Some(&"A".to_string()));
+        assert_eq!(hash_trie.get_view(keys_a).unwrap().value(), Some(&"A".to_string()));
     }
 
     #[test]
@@ -428,8 +428,8 @@ mod test {
 
         hash_trie.insert(keys_b.clone(), "B".to_string());
 
-        assert_eq!(hash_trie.get(keys_a).unwrap().value(), Some(&"A".to_string()));
+        assert_eq!(hash_trie.get_view(keys_a).unwrap().value(), Some(&"A".to_string()));
 
-        assert_eq!(hash_trie.get(keys_b).unwrap().value(), Some(&"B".to_string()));
+        assert_eq!(hash_trie.get_view(keys_b).unwrap().value(), Some(&"B".to_string()));
     }
 }

--- a/src/trie/mod.rs
+++ b/src/trie/mod.rs
@@ -13,7 +13,7 @@ pub trait Trie<K, V>: Sized {
     fn as_view(self) -> Self::View;
     
     /// Gets the View for the specified node if it exists
-    fn get<T>(self, path: T) -> Option<Self::View>
+    fn get_view<T>(self, path: T) -> Option<Self::View>
         where
             T: IntoIterator<Item=K> {
 


### PR DESCRIPTION
according @Kylebrown9's comment [here](https://github.com/Randevelopment/Slang/issues/6#issue-413070674) in #6.